### PR TITLE
Initialize Claude Code project configuration

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,10 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__awslabs_aws-documentation-mcp-server__search_documentation",
+      "mcp__awslabs_aws-documentation-mcp-server__read_documentation",
+      "mcp__awslabs_aws-documentation-mcp-server__read_sections",
+      "mcp__awslabs_aws-documentation-mcp-server__recommend"
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,6 +8,7 @@
     ]
   },
   "enabledPlugins": {
-    "aws-serverless@claude-plugins-official": true
+    "aws-serverless@claude-plugins-official": true,
+    "code-review@claude-plugins-official": true
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,5 +6,8 @@
       "mcp__awslabs_aws-documentation-mcp-server__read_sections",
       "mcp__awslabs_aws-documentation-mcp-server__recommend"
     ]
+  },
+  "enabledPlugins": {
+    "aws-serverless@claude-plugins-official": true
   }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,40 @@
+{
+  "mcpServers": {
+    "awslabs.aws-documentation-mcp-server": {
+      "command": "docker",
+      "args": [
+        "run",
+        "--rm",
+        "--interactive",
+        "--env",
+        "FASTMCP_LOG_LEVEL=ERROR",
+        "--env",
+        "AWS_DOCUMENTATION_PARTITION=aws",
+        "public.ecr.aws/awslabs-mcp/awslabs/aws-documentation-mcp-server:latest"
+      ],
+      "env": {},
+      "disabled": false,
+      "autoApprove": []
+    },
+    "awslabs-cloudwatch-mcp-server": {
+      "type": "stdio",
+      "command": "docker",
+      "args": [
+        "run",
+        "--rm",
+        "-i",
+        "-e",
+        "AWS_PROFILE=cerberus",
+        "-e",
+        "AWS_REGION=ca-central-1",
+        "-e",
+        "FASTMCP_LOG_LEVEL=ERROR",
+        "-v",
+        "${HOME}/.aws:/app/.aws:ro",
+        "public.ecr.aws/awslabs-mcp/awslabs/cloudwatch-mcp-server:latest"
+      ],
+      "env": {}
+    }
+  }
+}
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,40 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What This Repo Does
+
+Cerberus is an AWS SAM application that automatically removes unwanted default AWS Control Tower IAM Identity Center permission set assignments. It intercepts `CreateAccountAssignment` CloudTrail events and deletes the assignment when it matches configured regex patterns.
+
+## Two-Account Deployment
+
+This app spans two AWS accounts:
+
+- **Management account**: `cft-eventbridge-rule.yaml` is a standalone CloudFormation template (not SAM) that forwards `sso:CreateAccountAssignment` events cross-account to the custom event bus in the delegated admin account.
+- **Delegated admin account**: `cerberus/template.yaml` is the SAM app. Deploy here.
+
+Never conflate these two templates. `sam build` / `sam deploy` only touch `cerberus/`.
+
+## Critical Code Quirk
+
+`cerberus/src/cerberus/app.py` around line 120 unconditionally overwrites the real `sso:DeleteAccountAssignment` API response with a hardcoded `{"AccountAssignmentDeletionStatus": {"Status": "SUCCEEDED"}}`. This means the function always reports success regardless of what the API actually returned. Verify intent with the team before modifying this function or adding response-based branching logic.
+
+## Primary Tuning Surface
+
+The three Lambda environment variables below are the main way to control what gets deleted. They are regex patterns set in `cerberus/template.yaml`:
+
+- `PermissionSetNamePattern`
+- `PrincipalGroupNamePattern`
+- `PrincipalUserNameEmail`
+
+## Testing
+
+Tests use stdlib `unittest`, not pytest. Do not add pytest dependencies or use pytest-style fixtures. Test file: `cerberus/tests/unit/test_cerberus.py`.
+
+## SAM / Step Functions / CloudFormation Work
+
+When working with `cerberus/template.yaml`, `cerberus/statemachine/cerberus.asl.json`, or `cft-eventbridge-rule.yaml`, use the `aws-serverless` MCP plugin (https://claude.ai/plugins/aws-serverless). It provides accurate resource schemas, ASL syntax validation, and SAM transform awareness that significantly reduces iteration on these files.
+
+## PR Requirements
+
+CODEOWNERS requires approval from both `@rewindio/AppSec` and `@rewindio/devops` before merging. Do not merge without both approvals.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,9 +31,13 @@ The three Lambda environment variables below are the main way to control what ge
 
 Tests use stdlib `unittest`, not pytest. Do not add pytest dependencies or use pytest-style fixtures. Test file: `cerberus/tests/unit/test_cerberus.py`.
 
-## SAM / Step Functions / CloudFormation Work
+## MCP Servers
 
-When working with `cerberus/template.yaml`, `cerberus/statemachine/cerberus.asl.json`, or `cft-eventbridge-rule.yaml`, use the `aws-serverless` MCP plugin (https://claude.ai/plugins/aws-serverless). It provides accurate resource schemas, ASL syntax validation, and SAM transform awareness that significantly reduces iteration on these files.
+Two MCP servers are configured in `.mcp.json` at the repo root. Use them proactively — don't guess at AWS API shapes or dig through logs manually.
+
+**`awslabs.aws-documentation-mcp-server`** — AWS official docs, resource schemas, IAM policy references, API signatures. Reach for this whenever you're working on `cerberus/template.yaml`, `cerberus/statemachine/cerberus.asl.json`, or `cft-eventbridge-rule.yaml`, or any time you need to verify an AWS API call, IAM action name, or resource attribute.
+
+**`awslabs-cloudwatch-mcp-server`** — Live CloudWatch access to the deployed Cerberus stack. Use this to debug Step Functions execution failures, inspect Lambda errors, or trace an event end-to-end. The default log group is `/cerberus` (parameterized at deploy time). The server is pre-configured with `AWS_PROFILE=cerberus` and `AWS_REGION=ca-central-1`; the `cerberus` profile must exist locally with CloudWatch read-only access (see `cerberus/README.md` for profile setup).
 
 ## PR Requirements
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,9 +37,13 @@ Two MCP servers are configured in `.mcp.json` at the repo root. Use them proacti
 
 **`awslabs.aws-documentation-mcp-server`** — AWS official docs, resource schemas, IAM policy references, API signatures. Reach for this whenever you're working on `cerberus/template.yaml`, `cerberus/statemachine/cerberus.asl.json`, or `cft-eventbridge-rule.yaml`, or any time you need to verify an AWS API call, IAM action name, or resource attribute.
 
-The **`aws-serverless` plugin** (`aws-serverless@claude-plugins-official`) is enabled at project scope in `.claude/settings.json`. It provides SAM-aware skills and serverless-specific context on top of the documentation MCP server.
-
 **`awslabs-cloudwatch-mcp-server`** — Live CloudWatch access to the deployed Cerberus stack. Use this to debug Step Functions execution failures, inspect Lambda errors, or trace an event end-to-end. The default log group is `/cerberus` (parameterized at deploy time). The server is pre-configured with `AWS_PROFILE=cerberus` and `AWS_REGION=ca-central-1`; the `cerberus` profile must exist locally with CloudWatch read-only access (see `cerberus/README.md` for profile setup).
+
+## Plugins
+
+The **`aws-serverless` plugin** (`aws-serverless@claude-plugins-official`) is enabled at project scope in `.claude/settings.json`. It provides SAM-aware skills and serverless-specific context for working with `cerberus/template.yaml`, `cerberus/statemachine/cerberus.asl.json`, and `cft-eventbridge-rule.yaml`.
+
+The **`code-review` plugin** (`code-review@claude-plugins-official`) is also enabled. See PR Requirements below.
 
 ## PR Requirements
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,4 +43,12 @@ The **`aws-serverless` plugin** (`aws-serverless@claude-plugins-official`) is en
 
 ## PR Requirements
 
+After opening a PR, run the `code-review` plugin before requesting human review:
+
+```
+/code-review
+```
+
+The plugin (`code-review@claude-plugins-official`) is enabled at project scope in `.claude/settings.json`. Use it to catch security, logic, and style issues before CODEOWNERS reviewers see the PR.
+
 CODEOWNERS requires approval from both `@rewindio/AppSec` and `@rewindio/devops` before merging. Do not merge without both approvals.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,12 +47,11 @@ The **`code-review` plugin** (`code-review@claude-plugins-official`) is also ena
 
 ## PR Requirements
 
-After opening a PR, run the `code-review` plugin before requesting human review:
+After opening a PR:
 
-```
-/code-review
-```
-
-The plugin (`code-review@claude-plugins-official`) is enabled at project scope in `.claude/settings.json`. Use it to catch security, logic, and style issues before CODEOWNERS reviewers see the PR.
+1. Run `/code-review` and read the full output before doing anything else
+2. Address any issues identified — push fixes to the branch if needed
+3. Post the complete `/code-review` output as a PR comment via `gh pr comment <number> --body "..."` so human reviewers have the analysis in context
+4. Only then request human review from CODEOWNERS
 
 CODEOWNERS requires approval from both `@rewindio/AppSec` and `@rewindio/devops` before merging. Do not merge without both approvals.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,8 @@ Two MCP servers are configured in `.mcp.json` at the repo root. Use them proacti
 
 **`awslabs.aws-documentation-mcp-server`** — AWS official docs, resource schemas, IAM policy references, API signatures. Reach for this whenever you're working on `cerberus/template.yaml`, `cerberus/statemachine/cerberus.asl.json`, or `cft-eventbridge-rule.yaml`, or any time you need to verify an AWS API call, IAM action name, or resource attribute.
 
+The **`aws-serverless` plugin** (`aws-serverless@claude-plugins-official`) is enabled at project scope in `.claude/settings.json`. It provides SAM-aware skills and serverless-specific context on top of the documentation MCP server.
+
 **`awslabs-cloudwatch-mcp-server`** — Live CloudWatch access to the deployed Cerberus stack. Use this to debug Step Functions execution failures, inspect Lambda errors, or trace an event end-to-end. The default log group is `/cerberus` (parameterized at deploy time). The server is pre-configured with `AWS_PROFILE=cerberus` and `AWS_REGION=ca-central-1`; the `cerberus` profile must exist locally with CloudWatch read-only access (see `cerberus/README.md` for profile setup).
 
 ## PR Requirements

--- a/cerberus/README.md
+++ b/cerberus/README.md
@@ -135,3 +135,31 @@ To delete the deployed stack, use:
 ```bash
 sam delete --stack-name "cerberus"
 ```
+
+## CloudWatch MCP Server
+
+The repo includes a pre-configured CloudWatch MCP server (`.mcp.json`) that gives Claude Code live read access to the deployed Cerberus stack — Step Functions execution history, Lambda logs, and CloudWatch metrics — without leaving the editor.
+
+### AWS Profile Setup
+
+The server expects a local AWS CLI profile named **`cerberus`** with read-only CloudWatch access. Create it using IAM Identity Center or a dedicated IAM user/role:
+
+```bash
+# Option A — SSO profile (recommended)
+aws configure sso --profile cerberus
+
+# Option B — static credentials
+aws configure --profile cerberus
+```
+
+Attach the AWS managed policy **`arn:aws:iam::aws:policy/CloudWatchLogsReadOnlyAccess`** to whichever principal the profile authenticates as. The MCP server only needs read access; do not grant write or broader permissions.
+
+The server targets `ca-central-1` by default (set in `.mcp.json`). If your stack is in a different region, update `AWS_REGION` in `.mcp.json` accordingly.
+
+### What It Gives You
+
+Once the profile is configured, Claude Code can query the `/cerberus` log group directly to:
+
+- Inspect Lambda invocation results and errors
+- Trace Step Functions execution failures end-to-end
+- Pull CloudWatch alarm history


### PR DESCRIPTION
## Summary

- Adds `CLAUDE.md` with project guidance for future Claude Code instances: two-account deployment pattern, critical code quirks, primary tuning surface (regex env vars), testing constraints (stdlib unittest), MCP server usage, and PR workflow
- Adds `.mcp.json` with two pre-configured MCP servers: AWS Documentation (official docs, API signatures, resource schemas) and CloudWatch (live read access to the deployed stack via the `cerberus` AWS profile)
- Adds `.claude/settings.json` with auto-approved permissions for AWS Documentation MCP read actions and enabled plugins: `aws-serverless` and `code-review` from the official Anthropic marketplace
- Extends `cerberus/README.md` with CloudWatch MCP Server setup instructions including profile configuration and required IAM policy

## Test plan

- [x] Verify `.mcp.json` MCP servers connect — restart Claude Code in this repo and confirm both servers initialize without errors
- [x] Verify AWS Documentation MCP auto-approves — trigger a `search_documentation` call and confirm no permission prompt appears
- [x] Verify plugins load — run `/plugin` in Claude Code and confirm `aws-serverless` and `code-review` appear under Installed
- [x] Verify CloudWatch MCP connects — ensure the `cerberus` AWS CLI profile exists locally with `CloudWatchLogsReadOnlyAccess`, then trigger a log query

🤖 Generated with [Claude Code](https://claude.com/claude-code)