### PR TITLE
fix: surface real deletion failures and skip mgmt-account events

### DIFF
--- a/cerberus/samconfig.toml
+++ b/cerberus/samconfig.toml
@@ -8,6 +8,7 @@ stack_name = "cerberus"
 [default.build.parameters]
 cached = true
 parallel = true
+use_container = true
 
 [default.validate.parameters]
 lint = true

--- a/cerberus/src/cerberus/app.py
+++ b/cerberus/src/cerberus/app.py
@@ -108,7 +108,10 @@ def lambda_handler(event, context):
                 )
             )
 
-            # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sso-admin/client/delete_account_assignment.html
+            # DeleteAccountAssignment is asynchronous — the initial response typically returns
+            # Status=IN_PROGRESS and the actual deletion completes later. Real failures surface
+            # as exceptions (handled below). See:
+            # https://docs.aws.amazon.com/singlesignon/latest/APIReference/API_DeleteAccountAssignment.html
             response = client.delete_account_assignment(
                 InstanceArn=instanceArn,
                 TargetId=targetId,
@@ -117,24 +120,33 @@ def lambda_handler(event, context):
                 PrincipalType=principalType,
                 PrincipalId=principalId,
             )
-            response = {"AccountAssignmentDeletionStatus": {"Status": "SUCCEEDED"}}
+            status_obj = response.get("AccountAssignmentDeletionStatus", {})
+            status = status_obj.get("Status")
+            request_id = status_obj.get("RequestId")
+            logger.info(
+                "Account assignment deletion request accepted (status=%s, requestId=%s).",
+                status,
+                request_id,
+            )
 
-            if (
-                response.get("AccountAssignmentDeletionStatus").get("Status")
-                == "SUCCEEDED"
-            ):
-                logger.info("Account assignment deletion succeeded.")
-                return {
-                    "result": "SUCCESS",
-                    "message": "Account assignment deletion succeeded.",
-                }
-            else:
-                logger.error("Account assignment deletion failed: %s", response)
+            if status == "FAILED":
+                failure_reason = status_obj.get("FailureReason", "unknown")
+                logger.error(
+                    "Account assignment deletion failed at API: %s", failure_reason
+                )
                 return {
                     "result": "FAILED",
                     "message": "Account assignment deletion failed.",
                     "details": response,
                 }
+
+            return {
+                "result": "SUCCESS",
+                "message": "Account assignment deletion request accepted (status={}).".format(
+                    status
+                ),
+                "details": response,
+            }
         else:
             logger.info(
                 "Principal '{}' ({}) does not match Control Tower provisioned access pattern. No action taken.".format(

--- a/cerberus/src/cerberus/app.py
+++ b/cerberus/src/cerberus/app.py
@@ -108,9 +108,10 @@ def lambda_handler(event, context):
                 )
             )
 
-            # DeleteAccountAssignment is asynchronous — the initial response typically returns
-            # Status=IN_PROGRESS and the actual deletion completes later. Real failures surface
-            # as exceptions (handled below). See:
+            # DeleteAccountAssignment is async: the initial response usually returns
+            # Status=IN_PROGRESS and the actual deletion completes later. Treat any non-FAILED
+            # status as accepted; a synchronous Status=FAILED (rare — e.g. target out of scope)
+            # or any client.exceptions.* is a real failure. See:
             # https://docs.aws.amazon.com/singlesignon/latest/APIReference/API_DeleteAccountAssignment.html
             response = client.delete_account_assignment(
                 InstanceArn=instanceArn,

--- a/cerberus/statemachine/cerberus.asl.json
+++ b/cerberus/statemachine/cerberus.asl.json
@@ -19,8 +19,16 @@
       "Type": "Choice",
       "Choices": [
         {
-          "Variable": "$.RequestParameters.targetId",
-          "StringEquals": "${ManagementAccountId}",
+          "And": [
+            {
+              "Variable": "$.RequestParameters.targetId",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.RequestParameters.targetId",
+              "StringEquals": "${ManagementAccountId}"
+            }
+          ],
           "Next": "Skip Management Account Target"
         }
       ],

--- a/cerberus/statemachine/cerberus.asl.json
+++ b/cerberus/statemachine/cerberus.asl.json
@@ -13,7 +13,27 @@
         "RequestParameters.$": "$.detail.requestParameters",
         "UserArn.$": "$.detail.userIdentity.arn"
       },
-      "Next": "Is CreateAccountAssignment Action?"
+      "Next": "Is Target Management Account?"
+    },
+    "Is Target Management Account?": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "$.RequestParameters.targetId",
+          "StringEquals": "${ManagementAccountId}",
+          "Next": "Skip Management Account Target"
+        }
+      ],
+      "Default": "Is CreateAccountAssignment Action?"
+    },
+    "Skip Management Account Target": {
+      "Type": "Pass",
+      "Result": {
+        "result": "SKIPPED",
+        "reason": "Target is the Management account; delegated admin cannot modify Management-account assignments."
+      },
+      "ResultPath": "$.SkipReason",
+      "End": true
     },
     "Is CreateAccountAssignment Action?": {
       "Type": "Choice",

--- a/cerberus/template.yaml
+++ b/cerberus/template.yaml
@@ -95,6 +95,7 @@ Resources:
       DefinitionUri: statemachine/cerberus.asl.json
       DefinitionSubstitutions:
         CerberusFunctionArn: !GetAtt CerberusFunction.Arn
+        ManagementAccountId: !Ref ManagementAccountId
       Policies:
         - CloudWatchPutMetricPolicy: {}
         - Statement:

--- a/cerberus/tests/unit/test_cerberus.py
+++ b/cerberus/tests/unit/test_cerberus.py
@@ -35,7 +35,8 @@ class TestLambdaHandler(unittest.TestCase):
         }
         result = lambda_handler(event, None)
         self.assertEqual(result["result"], "SUCCESS")
-        self.assertIn("Account assignment deletion succeeded", result["message"])
+        self.assertIn("SUCCEEDED", result["message"])
+        self.assertIn("AccountAssignmentDeletionStatus", result["details"])
 
     @patch("cerberus.src.cerberus.app.logger")
     @patch("cerberus.src.cerberus.app.client", new_callable=MagicMock)
@@ -98,3 +99,120 @@ class TestLambdaHandler(unittest.TestCase):
         result = lambda_handler(event, None)
         self.assertEqual(result["result"], "FAILED")
         self.assertIn("Invalid regex pattern", result["message"])
+
+    @patch("cerberus.src.cerberus.app.logger")
+    @patch("cerberus.src.cerberus.app.client", new_callable=MagicMock)
+    def test_lambda_handler_in_progress_status(self, mock_client, mock_logger):
+        event = {
+            "DescribeInstance": {
+                "InstanceArn": "arn:aws:sso:::instance/sso-instance-id"
+            },
+            "RequestParameters": {
+                "targetId": "target-id",
+                "targetType": "AWS_ACCOUNT",
+                "principalType": "USER",
+                "principalId": "user-id",
+            },
+            "DescribePermissionSet": {
+                "PermissionSet": {
+                    "PermissionSetArn": "arn:aws:sso:::permissionSet/sso-instance-id/permission-set-id",
+                    "Name": "MatchingPermissionSetName",
+                }
+            },
+            "DescribeUser": {"UserName": "matchinguser@example.com"},
+        }
+        os.environ["PermissionSetNamePattern"] = "^MatchingPermissionSetName$"
+        os.environ["PrincipalGroupNamePattern"] = "^MatchingGroupName$"
+        os.environ["PrincipalUserNameEmail"] = "matchinguser@example.com"
+        mock_client.delete_account_assignment.return_value = {
+            "AccountAssignmentDeletionStatus": {
+                "Status": "IN_PROGRESS",
+                "RequestId": "11111111-2222-3333-4444-555555555555",
+            }
+        }
+        result = lambda_handler(event, None)
+        self.assertEqual(result["result"], "SUCCESS")
+        self.assertIn("IN_PROGRESS", result["message"])
+        self.assertIn("AccountAssignmentDeletionStatus", result["details"])
+        mock_client.delete_account_assignment.assert_called_once()
+
+    @patch("cerberus.src.cerberus.app.logger")
+    @patch("cerberus.src.cerberus.app.client", new_callable=MagicMock)
+    def test_lambda_handler_status_failed(self, mock_client, mock_logger):
+        event = {
+            "DescribeInstance": {
+                "InstanceArn": "arn:aws:sso:::instance/sso-instance-id"
+            },
+            "RequestParameters": {
+                "targetId": "target-id",
+                "targetType": "AWS_ACCOUNT",
+                "principalType": "USER",
+                "principalId": "user-id",
+            },
+            "DescribePermissionSet": {
+                "PermissionSet": {
+                    "PermissionSetArn": "arn:aws:sso:::permissionSet/sso-instance-id/permission-set-id",
+                    "Name": "MatchingPermissionSetName",
+                }
+            },
+            "DescribeUser": {"UserName": "matchinguser@example.com"},
+        }
+        os.environ["PermissionSetNamePattern"] = "^MatchingPermissionSetName$"
+        os.environ["PrincipalGroupNamePattern"] = "^MatchingGroupName$"
+        os.environ["PrincipalUserNameEmail"] = "matchinguser@example.com"
+        mock_client.delete_account_assignment.return_value = {
+            "AccountAssignmentDeletionStatus": {
+                "Status": "FAILED",
+                "FailureReason": "Target account is out of scope.",
+                "RequestId": "99999999-2222-3333-4444-555555555555",
+            }
+        }
+        result = lambda_handler(event, None)
+        self.assertEqual(result["result"], "FAILED")
+        self.assertIn("Account assignment deletion failed", result["message"])
+        self.assertIn("AccountAssignmentDeletionStatus", result["details"])
+
+    @patch("cerberus.src.cerberus.app.logger")
+    @patch("cerberus.src.cerberus.app.client", new_callable=MagicMock)
+    def test_lambda_handler_access_denied(self, mock_client, mock_logger):
+        event = {
+            "DescribeInstance": {
+                "InstanceArn": "arn:aws:sso:::instance/sso-instance-id"
+            },
+            "RequestParameters": {
+                "targetId": "target-id",
+                "targetType": "AWS_ACCOUNT",
+                "principalType": "USER",
+                "principalId": "user-id",
+            },
+            "DescribePermissionSet": {
+                "PermissionSet": {
+                    "PermissionSetArn": "arn:aws:sso:::permissionSet/sso-instance-id/permission-set-id",
+                    "Name": "MatchingPermissionSetName",
+                }
+            },
+            "DescribeUser": {"UserName": "matchinguser@example.com"},
+        }
+        os.environ["PermissionSetNamePattern"] = "^MatchingPermissionSetName$"
+        os.environ["PrincipalGroupNamePattern"] = "^MatchingGroupName$"
+        os.environ["PrincipalUserNameEmail"] = "matchinguser@example.com"
+
+        AccessDeniedException = type("AccessDeniedException", (Exception,), {})
+        mock_client.exceptions.AccessDeniedException = AccessDeniedException
+        mock_client.exceptions.ConflictException = type(
+            "ConflictException", (Exception,), {}
+        )
+        mock_client.exceptions.ResourceNotFoundException = type(
+            "ResourceNotFoundException", (Exception,), {}
+        )
+        mock_client.exceptions.ValidationException = type(
+            "ValidationException", (Exception,), {}
+        )
+        mock_client.delete_account_assignment.side_effect = AccessDeniedException(
+            "User is not authorized to perform this action."
+        )
+
+        result = lambda_handler(event, None)
+        self.assertEqual(result["result"], "FAILED")
+        self.assertEqual(result["errorName"], "AccessDeniedException")
+        self.assertIn("Access denied", result["message"])


### PR DESCRIPTION
## Summary

- Drop the line 120 hardcoded SUCCEEDED override in `cerberus/src/cerberus/app.py`. The Lambda was masking real `DeleteAccountAssignment` failures (`AccessDeniedException`, throttling, validation) — the state machine's `ExecutionsFailed` alarm could not fire because every invocation reported success. Treat `IN_PROGRESS` as "request accepted" (the API is asynchronous per [AWS docs](https://docs.aws.amazon.com/singlesignon/latest/APIReference/API_DeleteAccountAssignment.html)) and only `Status==FAILED` returns FAILED; existing exception handlers continue to catch hard errors. Status and RequestId are now logged for traceability.
- Add an `Is Target Management Account?` Choice state immediately after `Process Event Details`. Events targeting the management account short-circuit before any `Describe*` calls or the Lambda invocation. Without this, line 120's removal would re-introduce a permanent `AccessDeniedException` on every Control-Tower-default assignment created against the management account itself (delegated admin cannot modify those). Sources `ManagementAccountId` from the existing CFN parameter via SAM `DefinitionSubstitutions` — no new IAM, no SSM dependency. The Choice has an `IsPresent` guard on `$.RequestParameters.targetId` to mirror the pattern used by adjacent Choice states.
- Tests: 6 unit tests (was 3). Adds `IN_PROGRESS`, `FAILED`, and `AccessDenied` paths.

## Test plan

- [x] `python -m unittest discover -s cerberus/tests/unit -v` — 6/6 pass
- [x] `sam validate --lint` — valid template
- [x] `sam build` — substitutions resolve
- [ ] Post-deploy: trigger a `CreateAccountAssignment` with `targetId == ManagementAccountId`; confirm execution short-circuits at `Is Target Management Account?` → `Skip Management Account Target` → end, with no Lambda invocation.
- [ ] Post-deploy: trigger against a non-mgmt account default permission set; confirm Lambda logs the actual `Status` and `RequestId` and reports SUCCESS.
- [ ] Post-deploy: confirm no spurious `ExecutionsFailed` alarms over a 24h soak.

## Deferred to follow-up work

- **State-machine integration test for the mgmt-account skip path.** Promised in the original onboarding plan but slipped from this PR; bundling it into PR2 (regex hardening) which already touches the test infrastructure. Today the skip is verified only by manual reasoning + the post-deploy live trace above.
- **`DescribeAccountAssignmentDeletionStatus` polling for verifying async completion.** Today's behavior (treat any non-FAILED initial response as accepted) is correct for the alarm path but does not confirm terminal state. Tracked as a separate ticket.

Generated with [Claude Code](https://claude.com/claude-code)