### PR TITLE
chore: update CODEOWNERS team refs to rewind-community

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,6 +2,6 @@
 
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence, member of
-# @rewindio will be requested for review when someone  opens 
+# @rewind-community will be requested for review when someone  opens
 # a pull request.
-*       @rewindio/AppSec @rewindio/devops
+*       @rewind-community/appsec @rewind-community/devops


### PR DESCRIPTION
# **Jira:** [DEVOPS-4349](https://rewind.atlassian.net/browse/DEVOPS-4349)

## Description of Change

This repo was moved from `rewindio` to `rewind-community`. CODEOWNERS still referenced `@rewindio/AppSec` and `@rewindio/devops`; cross-org team refs are silently dropped by GitHub, so codeowner review was effectively disabled. Updating to `@rewind-community/appsec` and `@rewind-community/devops` restores it.

## Related PRs

- rewindio/terraform-rewindio-github#365

## Testing Performed

Both `rewind-community/appsec` and `rewind-community/devops` confirmed to exist. Visual diff review.